### PR TITLE
Fix rustus systemd units not working with any user other than root

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ None.
         user: myuser
         # group that rustus will run as
         group: mygroup
+        # rustus will refuse to work if it cannot write to its current working directory,
+        # just provide a directory that rustus has write access to (for example the same
+        # directory where files will be uploaded)
+        working_directory: /data/uploads
         # arguments passed to rustus
         args:
           # see https://s3rius.github.io/rustus/configuration/

--- a/molecule/systemd/vars.yml
+++ b/molecule/systemd/vars.yml
@@ -1,16 +1,14 @@
 ---
 rustus_version: 0.7.2
 
-# The systemd User= directive prevents users other than root from writing to the uploads folder,
-# although strangely, when non-root users launch rustus without systemd everything works. Needs
-# further investigation.
-rustus_owner: root
-rustus_group: root
+rustus_owner: rustus
+rustus_group: rustus
 
 rustus_instances:
   - name: uploads
     user: "{{ rustus_owner }}"
     group: "{{ rustus_group }}"
+    working_directory: "{{ uploads_dir }}"
     args:
       - --host "127.0.0.1"
       - --port 10081

--- a/templates/rustus.service.j2
+++ b/templates/rustus.service.j2
@@ -11,6 +11,7 @@ UMask=022
 Type=simple
 User={{ item.user }}
 Group={{ item.group }}
+WorkingDirectory={{ item.working_directory }}
 TimeoutStartSec=10
 ExecStart={{ rustus_path }} {{ item.args | join(' ') }}
 Restart=always


### PR DESCRIPTION
rustus will refuse to work if it cannot write to its current working directory, so now a directory that rustus has write access to (for example the same directory where files will be uploaded) must be provided for systemd units