### PR TITLE
Fix "typo" in "Ansible Molecule (latest rustus)" GitHub Actions workflow

### DIFF
--- a/.github/workflows/molecule-latest.yml
+++ b/.github/workflows/molecule-latest.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - default
+          - latest
     steps:
       - name: Install Ansible Molecule.
         run: |


### PR DESCRIPTION
This workflow, which runs once a week, is supposed to run tests for the "latest" Molecule scenario, which checks whether the latest version of rustus is working.

However, at the moment it is running the "default" scenario.