### PR TITLE
Create working directories for systemd units automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ None.
         # --info-dir argument, although it defaults to "./data". This means that by default,
         # rustus will refuse to run if it cannot write to its current working directory.
         # Therefore, this role forces you to provide a working directory so that rustus can
-        # work even when the --info-dir argument is not provided.
+        # work even when the --info-dir argument is not provided. This working directory
+        # will be automatically created if it does not exist. 
         working_directory: /data/uploads
         # arguments passed to rustus
         args:

--- a/molecule/systemd/converge.yml
+++ b/molecule/systemd/converge.yml
@@ -12,13 +12,16 @@
       ansible.builtin.group:
         name: "{{ rustus_group }}"
         state: present
-    - name: Create uploads directory.
+    - name: Pre-create the uploads directory for one of the systemd units.
+      # This directory is supposed to keep its owner, group and permissions
+      # intact. They will be verified
+      #
       ansible.builtin.file:
-        path: "{{ uploads_dir }}"
+        path: "{{ existing_dir }}"
         state: directory
         owner: "{{ rustus_owner }}"
-        group: "{{ rustus_group }}"
-        mode: "0770"
+        group: root
+        mode: "{{ existing_dir_mode }}"
   tasks:
     - name: "Include usegalaxy_eu.rustus"
       ansible.builtin.include_role:

--- a/molecule/systemd/vars.yml
+++ b/molecule/systemd/vars.yml
@@ -16,4 +16,18 @@ rustus_instances:
       - --log-level "INFO"
       - "--data-dir {{ uploads_dir }}"
 
+  # Test `working_directory` already existing.
+  - name: existing
+    user: "{{ rustus_owner }}"
+    group: "{{ rustus_group }}"
+    working_directory: "{{ existing_dir }}"
+    args:
+      - --host "127.0.0.1"
+      - --port 10082
+      - --url "/uploads"
+      - --log-level "INFO"
+      - "--data-dir {{ existing_dir }}"
+
 uploads_dir: /uploads
+existing_dir: /existing
+existing_dir_mode: "0774"

--- a/molecule/systemd/verify.yml
+++ b/molecule/systemd/verify.yml
@@ -77,3 +77,26 @@
             ls -lah {{ uploads_dir }} | wc -l
           register: __count_clean
           changed_when: __count.stdout != __count_clean.stdout
+
+    - name: Verify that the permissions of the already existing working directory remained unchanged.
+      block:
+        - name: Gather information about the working directory.
+          ansible.builtin.stat:
+            path: "{{ existing_dir }}"
+          register: __stat_existing_dir
+
+        - name: Retrieve user details.
+          ansible.builtin.getent:
+            database: passwd
+
+        - name: Verify that the owner remained unchanged.
+          ansible.builtin.assert:
+            that: __stat_existing_dir.stat.uid == {{ getent_passwd[rustus_owner].1 }}
+
+        - name: Verify that the group remained unchanged.
+          ansible.builtin.assert:
+            that: __stat_existing_dir.stat.gid == {{ getent_passwd['root'].2 }}
+
+        - name: Verify that the mode remained unchanged.
+          ansible.builtin.assert:
+            that: __stat_existing_dir.stat.mode == existing_dir_mode

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,4 +1,22 @@
 ---
+- name: Ensure the working directories for each systemd service unit exist.
+  block:
+    - name: Check whether the directories exists.
+      ansible.builtin.stat:
+        path: "{{ instance.working_directory }}"
+      loop: "{{ rustus_instances }}"
+      loop_control:
+        loop_var: instance
+      register: __stat_working_directory
+
+    - name: Create the working directories if they do not exist.
+      ansible.builtin.file:
+        path: "{{ item.instance.working_directory }}"
+        state: directory
+        owner: "{{ item.instance.user if not item.stat.exists else omit }}"
+        group: "{{ item.instance.group if not item.stat.exists else omit }}"
+        mode: "{{ existing_dir_mode if not item.stat.exists else omit }}"
+      loop: "{{ __stat_working_directory.results }}"
 
 # Using the systemd instance functionality doesn't work here beacuse the user/group cannot be an env var, but should not
 # necessarily be the same for all instances, so we resort to creating individual service units for each instance.


### PR DESCRIPTION
Create working directories for systemd units automatically if they do not exist. Existing directories will keep their permissions intact.

Includes test coverage.

Closes #6.