### PR TITLE
Exclude GitHub workflows from ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,5 @@
 ---
 kinds:
   - vars: "**/molecule/*/vars.yml"
+exclude_paths:
+  - .github/


### PR DESCRIPTION
Exclude the .github folder from ansible-lint.