### PR TITLE
Run Molecule tests using `ansible-compat==24.10.0`

### DIFF
--- a/.github/workflows/molecule-latest.yml
+++ b/.github/workflows/molecule-latest.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
       - name: Install Ansible Molecule.
         run: |
-          pip3 install --user molecule molecule-plugins[podman] ansible-core
+          pip3 install --user molecule molecule-plugins[podman] ansible-core ansible-compat==24.10.0
+          # `ansible-compat==24.10.0` is a workaround for an issue similar to
+          # https://github.com/ansible/ansible-compat/issues/455
 
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - name: Install Ansible Molecule.
         run: |
-          pip3 install --user molecule molecule-plugins[podman] ansible-core
+          pip3 install --user molecule molecule-plugins[podman] ansible-core ansible-compat==24.10.0
+          # `ansible-compat==24.10.0` is a workaround for an issue similar to
+          # https://github.com/ansible/ansible-compat/issues/455
 
       - name: Check out the codebase.
         uses: actions/checkout@v3


### PR DESCRIPTION
Workaround for an issue that causes tests to fail and is similar to https://github.com/ansible/ansible-compat/issues/455. The issue is triggered by the recent updates to `ansible-compat`.