### PR TITLE
Revert "Run Molecule tests using `ansible-compat==24.10.0`"

### DIFF
--- a/.github/workflows/molecule-latest.yml
+++ b/.github/workflows/molecule-latest.yml
@@ -17,9 +17,7 @@ jobs:
     steps:
       - name: Install Ansible Molecule.
         run: |
-          pip3 install --user molecule molecule-plugins[podman] ansible-core ansible-compat==24.10.0
-          # `ansible-compat==24.10.0` is a workaround for an issue similar to
-          # https://github.com/ansible/ansible-compat/issues/455
+          pip3 install --user molecule molecule-plugins[podman] ansible-core
 
       - name: Check out the codebase.
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,9 +22,7 @@ jobs:
     steps:
       - name: Install Ansible Molecule.
         run: |
-          pip3 install --user molecule molecule-plugins[podman] ansible-core ansible-compat==24.10.0
-          # `ansible-compat==24.10.0` is a workaround for an issue similar to
-          # https://github.com/ansible/ansible-compat/issues/455
+          pip3 install --user molecule molecule-plugins[podman] ansible-core
 
       - name: Check out the codebase.
         uses: actions/checkout@v3


### PR DESCRIPTION
Reverts usegalaxy-eu/ansible-rustus#14, the issue has been fixed in `ansible-compat` v25.1.4.